### PR TITLE
changed 'book_id' back to 'id'

### DIFF
--- a/api/types.ts
+++ b/api/types.ts
@@ -8,7 +8,7 @@ export type BookType = {
   rating: number
   start_date: string
   finish_date: string
-  book_id: number
+  id: number
   notes: string
 }
 

--- a/components/bookshelf/Book.tsx
+++ b/components/bookshelf/Book.tsx
@@ -38,7 +38,7 @@ const Book = ({ book, rating, section = "discover" }: BookProps) => {
 
   const addToList = () => {
     setStatus(StatusEnum.loading)
-    addToReadingList(book.book_id).then(() => {
+    addToReadingList(book.id).then(() => {
       setStatus(StatusEnum.reading)
       onRemove(book, "discover")
     })

--- a/components/bookshelf/detailedbook/DetailedBook.tsx
+++ b/components/bookshelf/detailedbook/DetailedBook.tsx
@@ -63,7 +63,7 @@ const DetailedBook = ({ book }: DetailedBookProps) => {
   }
 
   const addToList = () => {
-    addToReadingList(book.book_id).then((res) => {
+    addToReadingList(book.id).then((res) => {
       setUserBookID(res.user_book_id)
     })
   }

--- a/components/bookshelf/discover/Discover.tsx
+++ b/components/bookshelf/discover/Discover.tsx
@@ -28,7 +28,7 @@ const Discover = () => {
         discoverBooks &&
         discoverBooks.map((book) => {
           return (
-            <BookList key={book.book_id}>
+            <BookList key={book.id}>
               <Book book={book} />
             </BookList>
           )

--- a/context/BookContext.tsx
+++ b/context/BookContext.tsx
@@ -46,7 +46,7 @@ const initialBook = {
   rating: 0,
   start_date: "start",
   finish_date: "finish",
-  book_id: 123123,
+  id: 123123,
   notes: "notes",
 }
 


### PR DESCRIPTION
reverted back from using `book.book_id` to `book.id`, which made a lot more sense. This change is in relation to this [PR](https://github.com/macarron001/bookshelf-api/pull/37).